### PR TITLE
Remove experimental flag for use in latest terraform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,15 @@
-resource "local_file" "kubeconfig" {
-  sensitive_content = templatefile("${path.module}/kubeconfig-template.tpl", { contexts = var.contexts, clusters = var.clusters, users = var.users, colors = var.colors, current_context = var.current_context })
+resource "local_sensitive_file" "kubeconfig" {
+  content = templatefile("${path.module}/kubeconfig-template.tpl", { contexts = var.contexts, clusters = var.clusters, users = var.users, colors = var.colors, current_context = var.current_context })
   filename          = "./${var.filename}"
 }
 
 output "kubeconfig_path" {
-  value       = local_file.kubeconfig.filename
+  value       = local_sensitive_file.kubeconfig.filename
   description = "Path to the kubeconfig file"
 }
 
 output "kubeconfig_content" {
-  value       = yamldecode(local_file.kubeconfig.sensitive_content)
+  value       = yamldecode(local_sensitive_file.kubeconfig.content)
   description = "HCL representation of kubeconfig file contents"
   sensitive   = true
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,10 +1,9 @@
 terraform {
-  experiments      = [module_variable_optional_attrs]
-  required_version = ">=0.15.0"
+  required_version = ">=1.3.0"
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">=2.0.0"
+      version = ">=2.2.0"
     }
   }
 }


### PR DESCRIPTION
The latest terraform does not support the `experiments      = [module_variable_optional_attrs]` flag and so this module cannot be used with the latest terraform.  The `default` syntax for input variables in terraform 1.3.4 is adequate for this module so changes are minimal to fix it (mainly bumping the required tf version and removing the experiments line).

Also, fixes use of now deprecated of `sensitive_context` in `local_file` in favor of `local_sensitive_file`.

I have specifically not updated the README to reference a new version as that will only work once a new version has been published.
